### PR TITLE
add step in CI to push to github docker registry

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Deploy the Docker image to GitHub Package Registry
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
-        name: gartcimore/jb3
+        name: gartcimore/jb3/jb3
         dockerfile: Dockerfile.jb3only
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,3 +21,22 @@ jobs:
           ${{ runner.os }}-maven-
     - name: Build with Maven
       run: mvn -B package --file pom.xml
+
+    - name: Deploy the Docker image to GitHub Package Registry
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: gartcimore/jb3
+        dockerfile: Dockerfile.jb3only
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        registry: docker.pkg.github.com
+        tag_names: true
+
+    - name: Deploy the Docker image to GitHub Package Registry (latest tag)
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: gartcimore/jb3
+        dockerfile: Dockerfile.jb3only
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        registry: docker.pkg.github.com

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Deploy the Docker image to GitHub Package Registry
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
-        name: gartcimore/jb3/jb3
+        name: devnewton/jb3/jb3
         dockerfile: Dockerfile.jb3only
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,12 +31,3 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
         registry: docker.pkg.github.com
         tag_names: true
-
-    - name: Deploy the Docker image to GitHub Package Registry (latest tag)
-      uses: elgohr/Publish-Docker-Github-Action@master
-      with:
-        name: gartcimore/jb3
-        dockerfile: Dockerfile.jb3only
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-        registry: docker.pkg.github.com

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 jb3 is a KISS tribune powered by java, spring boot and mongodb.
 
+![](https://github.com/actions/jb3/workflows/Java%20CI/badge.svg)
 ## Features
 
 - archives

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 jb3 is a KISS tribune powered by java, spring boot and mongodb.
 
-![](https://github.com/gartcimore/jb3/workflows/Java%20CI/badge.svg)
+![](https://github.com/devnewton/jb3/workflows/Java%20CI/badge.svg)
 ## Features
 
 - archives

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 jb3 is a KISS tribune powered by java, spring boot and mongodb.
 
-![](https://github.com/actions/jb3/workflows/Java%20CI/badge.svg)
+![](https://github.com/gartcimore/jb3/workflows/Java%20CI/badge.svg)
 ## Features
 
 - archives
@@ -57,11 +57,13 @@ Implemented gateways:
 # Build and run demo using [docker](https://www.docker.com/)
 
 Run the following commands:
-
-    docker build --tag=jb3 https://github.com/devnewton/jb3.git
-    docker run -p 8080:8080 jb3
+```bash
+    docker build --tag=jb3 https://github.com/devnewton/jb3.git -f Dockerfile.jb3only
+    docker-compose up -d
+```
 
 Then access to the jb3 application using a web browser on http://localhost:8080
+This will runs two docker container, one for jb3 and one for mongodb. Mongodb data will be stored locally in *data* folder, allowing to keep it between runs.
 
 # How to use
 


### PR DESCRIPTION
C'est un example de comment pousser dans la registry docker de github. Pê ne pas le faire à chaque push ? On peut le faire sur un tag par exemple
Ensuite les gens peuvent faire :
docker pull docker.pkg.github.com/devnewton/jb3/jb3:master sans avoir besoin de construire l'image